### PR TITLE
refactor(scss): change class names convention to camelCase from kebab-case

### DIFF
--- a/src/pages/showcase/components/ShotCover/index.tsx
+++ b/src/pages/showcase/components/ShotCover/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './index.module.scss';
 
 const ShotCover: React.FC = ({ children }) => {
-  return <div className={styles['cover']}>{children}</div>;
+  return <div className={styles.cover}>{children}</div>;
 }
 
 export default ShotCover;

--- a/src/pages/showcase/components/ShotTitle/index.module.scss
+++ b/src/pages/showcase/components/ShotTitle/index.module.scss
@@ -1,8 +1,8 @@
-.shot-title {
+.shotTitle {
   display: flex;
   align-items: center;
 
-  > .shot-link {
+  > .shotLink {
     // Without this the `a` element won't be the same height as the icon (caused by antd card)
     line-height: 1;
 

--- a/src/pages/showcase/components/ShotTitle/index.tsx
+++ b/src/pages/showcase/components/ShotTitle/index.tsx
@@ -26,7 +26,7 @@ const ShotTitle: React.FC<ShotTitleProps> = ({ name, link, originalShotLink }) =
   if (originalShotLink) {
     originalShotComponent = (
       <Tooltip title="Original Shot">
-        <AntdLink href={originalShotLink} className={styles['shot-link']}>
+        <AntdLink href={originalShotLink} className={styles.shotLink}>
           <DribbbleIcon style={{ fontSize: '20px' }}/>
         </AntdLink>
       </Tooltip>
@@ -34,7 +34,7 @@ const ShotTitle: React.FC<ShotTitleProps> = ({ name, link, originalShotLink }) =
   }
 
   return (
-    <div className={styles['shot-title']}>
+    <div className={styles.shotTitle}>
       {originalShotComponent}
       <div>{titleComponent}</div>
     </div>

--- a/src/pages/showcase/index.module.scss
+++ b/src/pages/showcase/index.module.scss
@@ -1,29 +1,31 @@
 .layout {
   height: 100%;
-}
 
-.title {
-  text-align: center;
-  color: white !important;
-}
+  .title {
+    text-align: center;
+    color: white !important;
+  }
 
-.content {
-  padding: 25px;
-}
+  .content {
+    padding: 25px;
 
-.showcase-container {
-  background-color: #F5F5F5;
 
-  display: grid;
+    .showcaseContainer {
+      background-color: #F5F5F5;
 
-  // Max of 4 items in each row, when resizing the width of the page the number of column should reduce
-  //
-  // We're using `#{"max(150px, 24%)"}` because using max with px and % are unsupported,
-  // so this is a workaround from [here](https://github.com/sass/node-sass/issues/2815#issuecomment-574038619)
-  //
-  // We're using 24% because if we use 25% it will create 3 columns in each row (at max) instead of 4
-  grid-template-columns: repeat(auto-fill, minmax(#{"max(150px, 24%)"}, 1fr));
+      display: grid;
 
-  // TODO (rluvaton): make the rows fill the screen
-  gap: 10px;
+      // Max of 4 items in each row, when resizing the width of the page the number of column should reduce
+      //
+      // We're using `#{"max(150px, 24%)"}` because using max with px and % are unsupported,
+      // so this is a workaround from [here](https://github.com/sass/node-sass/issues/2815#issuecomment-574038619)
+      //
+      // We're using 24% because if we use 25% it will create 3 columns in each row (at max) instead of 4
+      grid-template-columns: repeat(auto-fill, minmax(#{"max(150px, 24%)"}, 1fr));
+
+      // TODO (rluvaton): make the rows fill the screen
+      gap: 10px;
+    }
+
+  }
 }

--- a/src/pages/showcase/index.tsx
+++ b/src/pages/showcase/index.tsx
@@ -10,14 +10,14 @@ const { Header, Content } = Layout;
 
 const ShowcasePage: React.FC = () => {
   return (
-    <Layout className={styles['layout']}>
+    <Layout className={styles.layout}>
 
       <Header>
-        <Title className={styles['title']}>Showcase</Title>
+        <Title className={styles.title}>Showcase</Title>
       </Header>
 
-      <Content className={styles['content']}>
-        <div className={styles['showcase-container']}>
+      <Content className={styles.content}>
+        <div className={styles.showcaseContainer}>
           {allShots.map((shot) => <ShotPreview key={shot.id} {...shot} />)}
         </div>
       </Content>


### PR DESCRIPTION
I did this transaction because it's easier to reference it in js (e.g instead of `styles['showcase-container']` do `styles.showcaseContainer`)