### PR TITLE
feat(showcase): add GitHub Icon with link to the repository

### DIFF
--- a/src/common/components/GitHubIconButton/index.module.scss
+++ b/src/common/components/GitHubIconButton/index.module.scss
@@ -1,0 +1,11 @@
+.githubButton {
+  font-size: 1em;
+
+  // Without it, changing the font size have problems.
+  width: fit-content;
+  height: fit-content;
+
+  .githubIcon {
+    font-size: inherit;
+  }
+}

--- a/src/common/components/GitHubIconButton/index.tsx
+++ b/src/common/components/GitHubIconButton/index.tsx
@@ -1,0 +1,16 @@
+import { GithubOutlined } from '@ant-design/icons';
+import React from 'react';
+import { Button } from 'antd';
+import styles from './index.module.scss';
+
+
+const GitHubIconButton: React.FC<{ iconClassName?: string } & React.ComponentProps<typeof Button>> = ({iconClassName, className: buttonClassName, ...buttonProps}) => (
+  <Button type="text"
+          {...buttonProps}
+          className={`${styles.githubButton} ${buttonClassName || ''}`}
+          icon={<GithubOutlined className={`${styles.githubIcon} ${iconClassName || ''}`}/>}
+  />
+);
+
+
+export default GitHubIconButton;

--- a/src/pages/showcase/index.module.scss
+++ b/src/pages/showcase/index.module.scss
@@ -1,9 +1,52 @@
 .layout {
   height: 100%;
 
-  .title {
-    text-align: center;
-    color: white !important;
+  .header {
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: center;
+
+    padding: 0 20px;
+
+    .title {
+
+      // We need the width as a variable because we use it in the margin-left calculations.
+      $width: 180px;
+      width: $width;
+
+
+      margin: {
+        top: 0;
+        bottom: 0;
+        right: auto;
+
+        // position it in the middle.
+        left: calc(50% - #{$width} / 2);
+      };
+
+      transition: margin-left 0.5s;
+
+      /* For Mobile */
+      @media screen and (max-width: 540px) {
+        & {
+          // Make the title be at the right
+          margin-left: 0;
+        }
+      }
+
+      padding-bottom: 4px;
+      flex: 0;
+
+      color: white !important;
+    }
+
+    .githubButton {
+      font-size: 2.5em;
+
+      .githubIcon {
+        color: rgba(255, 255, 255, 1);
+      }
+    }
   }
 
   .content {

--- a/src/pages/showcase/index.test.tsx
+++ b/src/pages/showcase/index.test.tsx
@@ -40,9 +40,7 @@ describe('ShowcasePage', () => {
     render(<ShowcasePage/>);
 
     // Assert
-    const shotTitleElement = screen.queryByText('Showcase');
-
-    expect(shotTitleElement).toBeInTheDocument();
+    screen.getByText('Showcase');
   });
 
   it('should render the page and display the shot components', () => {
@@ -67,6 +65,21 @@ describe('ShowcasePage', () => {
     // Assert
     screen.getByText('Showcase');
     shots.forEach(shot => screen.getByTestId(getShotComponentTestId(shot)));
+  });
+
+  it('should have the Github icon', () => {
+    // Arrange
+    const shots: Shot[] = [];
+
+
+    const ShowcasePage = mockShotsAndGetComponent(shots);
+
+    // Act
+    render(<ShowcasePage/>);
+
+    // Assert
+    // The GitHub Icon have the `aria-label=github` in it
+    screen.getByLabelText('github');
   });
 
 });

--- a/src/pages/showcase/index.tsx
+++ b/src/pages/showcase/index.tsx
@@ -3,6 +3,7 @@ import styles from './index.module.scss';
 import ShotPreview from './components/ShotPreview';
 import { Layout, Typography } from 'antd';
 import { allShots } from '../shots';
+import GitHubIconButton from '../../common/components/GitHubIconButton';
 
 const { Title } = Typography;
 const { Header, Content } = Layout;
@@ -12,7 +13,9 @@ const ShowcasePage: React.FC = () => {
   return (
     <Layout className={styles.layout}>
 
-      <Header>
+      <Header className={styles.header}>
+        <GitHubIconButton className={styles.githubButton} iconClassName={styles.githubIcon}
+                          href="https://github.com/rluvaton/dribbble-shots-recreation" />
         <Title className={styles.title}>Showcase</Title>
       </Header>
 


### PR DESCRIPTION
Also, when the screen is getting smaller, than the header move right

Closes #9