### PR TITLE
feat(shot-container): add Dribbble icon with a link to the shot

### DIFF
--- a/src/pages/shots/ShotContainer/components/DesignedBy/index.module.scss
+++ b/src/pages/shots/ShotContainer/components/DesignedBy/index.module.scss
@@ -1,8 +1,0 @@
-.designedBy {
-  transition: opacity 0.5s ease-in-out;
-  opacity: 0.5;
-
-  &:hover {
-    opacity: 1;
-  }
-}

--- a/src/pages/shots/ShotContainer/components/DesignedBy/index.tsx
+++ b/src/pages/shots/ShotContainer/components/DesignedBy/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styles from './index.module.scss';
 import { Typography } from 'antd';
 
 const { Link } = Typography;
@@ -11,7 +10,7 @@ interface DesignedByProps {
 
 const DesignedBy: React.FC<DesignedByProps> = ({ author, link }) => {
   return (
-    <span className={styles.designedBy}>Designed by <Link href={link}>{author}</Link></span>
+    <span>Designed by <Link href={link}>{author}</Link></span>
   )
 }
 

--- a/src/pages/shots/ShotContainer/index.module.scss
+++ b/src/pages/shots/ShotContainer/index.module.scss
@@ -8,11 +8,31 @@
   > .info {
     position: absolute;
 
-    width: fit-content;
     bottom: 26px;
     left: 30px;
+    width: fit-content;
 
-    font-family: 'JetBrains Mono', source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+
+    font-family: 'JetBrains Mono', source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+
+
+    display: flex;
+    align-items: center;
+
+
+    transition: opacity 0.5s ease-in-out;
+    opacity: 0.5;
+
+    &:hover {
+      opacity: 1;
+    }
+
+
+    > .shotLink {
+      // force the `a` element be the same height as the icon (caused by the antd Link)
+      line-height: 1;
+
+      margin-right: 10px;
+    }
   }
 }

--- a/src/pages/shots/ShotContainer/index.test.tsx
+++ b/src/pages/shots/ShotContainer/index.test.tsx
@@ -10,7 +10,7 @@ describe('ShotContainer', () => {
     expect(ShotContainer).toBeDefined();
   });
 
-  it('should render the component display the author name', () => {
+  it('should render the component and display the author name and the dribbble icon', () => {
     // Arrange
     const shotComponentTestId = 'shot-component';
     const shot: Shot = shotBuilder({
@@ -28,6 +28,6 @@ describe('ShotContainer', () => {
     screen.getByText(shot.author.name);
 
     const links = getAllHrefInContainer(container);
-    expect(links).toEqual([shot.author.link]);
+    expect(links).toIncludeSameMembers([shot.author.link, shot.originalShotLink]);
   });
 });

--- a/src/pages/shots/ShotContainer/index.tsx
+++ b/src/pages/shots/ShotContainer/index.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import styles from './index.module.scss';
 import { Shot } from '../../../common/interfaces/shot';
 import DesignedBy from './components/DesignedBy';
+import DribbbleIcon from '../../../common/components/DribbbleIcon';
+import { Typography } from 'antd';
+
+const { Link } = Typography;
 
 interface ShotContainerProps {
   shot: Shot
@@ -13,6 +17,9 @@ const ShotContainer: React.FC<ShotContainerProps> = ({ shot }) => {
       <div className={styles.component}>{shot.createComponent()}</div>
 
       <div className={styles.info}>
+        <Link href={shot.originalShotLink} className={styles.shotLink}>
+          <DribbbleIcon style={{ fontSize: '20px' }}/>
+        </Link>
         <DesignedBy author={shot.author.name} link={shot.author.link}/>
       </div>
 

--- a/src/pages/showcase/components/ShotTitle/index.module.scss
+++ b/src/pages/showcase/components/ShotTitle/index.module.scss
@@ -3,7 +3,7 @@
   align-items: center;
 
   > .shotLink {
-    // Without this the `a` element won't be the same height as the icon (caused by antd card)
+    // Without this the `a` element won't be the same height as the icon (caused by antd card and/or the link)
     line-height: 1;
 
     margin-right: 5px;


### PR DESCRIPTION
Closes #29