### PR TITLE
fix(showcase): only display shots scrollbar if there's not enough space

### DIFF
--- a/src/pages/Showcase/index.module.scss
+++ b/src/pages/Showcase/index.module.scss
@@ -54,7 +54,7 @@
 
     // Fix #37 - background not filling the whole page
     // Could be fixed by setting the background on the body but prefer not to do it as it is only needed in one page
-    overflow-y: scroll;
+    overflow-y: auto;
 
     .showcaseContainer {
       display: grid;


### PR DESCRIPTION
Close #49